### PR TITLE
Let Eeschema find libngspice.so in /app/lib

### DIFF
--- a/org.kicad_pcb.KiCad.json
+++ b/org.kicad_pcb.KiCad.json
@@ -9,6 +9,7 @@
     "rename-appdata-file": "kicad.appdata.xml",
     "finish-args": [
         "--device=dri",
+        "--env=LD_LIBRARY_PATH=/app/lib",
         "--filesystem=home",
         "--share=ipc",
         "--share=network",


### PR DESCRIPTION
Upon its first invocation from Eeschema, the KiCad simulator tries to
load `libngspice.so`. This library is installed in `/app/lib`, but this
path is not in `LD_LIBRARY_PATH` when launching the sandbox. Thus, add
it into "finish_args".