### PR TITLE
Activate Python scripting

### DIFF
--- a/fix-cmake-ninja-build.patch
+++ b/fix-cmake-ninja-build.patch
@@ -1,0 +1,65 @@
+From 51511eda85809cd6142bff17d705b0f5078aca7f Mon Sep 17 00:00:00 2001
+From: Seth Hillbrand <hillbrand@ucdavis.edu>
+Date: Thu, 13 Jun 2019 06:00:24 -0700
+Subject: [PATCH] CMake adjust Linux build
+
+Instead of linking the same target name and re-building, we can install
+the file to a new name.  This speeds the build process and keeps linking
+routines from stepping on each other.  Available now that we are at
+CMake 3.0.2
+
+Fixes: lp:1789468
+* https://bugs.launchpad.net/kicad/+bug/1789468
+---
+ pcbnew/CMakeLists.txt | 28 +++++++++++-----------------
+ 1 file changed, 11 insertions(+), 17 deletions(-)
+
+diff --git a/pcbnew/CMakeLists.txt b/pcbnew/CMakeLists.txt
+index 4c14aaa68..92ac8c404 100644
+--- a/pcbnew/CMakeLists.txt
++++ b/pcbnew/CMakeLists.txt
+@@ -773,11 +773,7 @@ if( KICAD_SCRIPTING_MODULES )
+         add_dependencies( ScriptingModulesPcbnewSoCopy ScriptingWxpythonCopy )
+         set( PYMOD_EXT "so" )
+     else()  # only linux remains among supported platforms
+-        add_library( pcbnew_python MODULE $<TARGET_OBJECTS:pcbnew_kiface_objects> )
+-        target_link_libraries( pcbnew_python ${PCBNEW_KIFACE_LIBRARIES} )
+-        set_target_properties( pcbnew_python PROPERTIES OUTPUT_NAME pcbnew PREFIX "_" SUFFIX ".so" )
+-        install( TARGETS pcbnew_python DESTINATION ${PYTHON_DEST} COMPONENT binary )
+-
++        install( FILES ${CMAKE_CURRENT_BINARY_DIR}/_pcbnew.kiface DESTINATION ${PYTHON_DEST} COMPONENT binary RENAME "_pcbnew.so" )
+         set( PYMOD_EXT "so" )
+     endif()
+ 
+@@ -792,18 +788,16 @@ if( KICAD_SCRIPTING_MODULES )
+             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/_pcbnew.${PYMOD_EXT}
+             )
+     else()
+-
+-
+-    # For phase 1, copy _pcbnew.kiface to the python module.
+-    add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_pcbnew.${PYMOD_EXT}
+-        DEPENDS pcbnew_kiface
+-        COMMAND ${CMAKE_COMMAND} -E copy _pcbnew.kiface _pcbnew.${PYMOD_EXT}
+-        COMMENT "Creating python's pcbnew native module _pcbnew.${PYMOD_EXT} for command line use."
+-        )
+-    add_custom_target(
+-        pcbnew_python_module ALL
+-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/_pcbnew.${PYMOD_EXT}
+-        )
++        # For phase 1, copy _pcbnew.kiface to the python module.
++        add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_pcbnew.${PYMOD_EXT}
++            DEPENDS pcbnew_kiface
++            COMMAND ${CMAKE_COMMAND} -E copy _pcbnew.kiface _pcbnew.${PYMOD_EXT}
++            COMMENT "Creating python's pcbnew native module _pcbnew.${PYMOD_EXT} for command line use."
++            )
++        add_custom_target(
++            pcbnew_python_module ALL
++            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/_pcbnew.${PYMOD_EXT}
++            )
+     endif()
+ 
+ endif()
+-- 
+2.26.2
+

--- a/org.kicad_pcb.KiCad.json
+++ b/org.kicad_pcb.KiCad.json
@@ -33,11 +33,12 @@
         {
             "name": "wxWidgets",
             "rm-configure": true,
+            "subdir": "ext/wxWidgets",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.2/wxWidgets-3.1.2.tar.bz2",
-                    "sha256": "4cb8d23d70f9261debf7d6cfeca667fc0a7d2b6565adb8f1c484f9b674f1f27a"
+                    "url": "https://files.pythonhosted.org/packages/b9/8b/31267dd6d026a082faed35ec8d97522c0236f2e083bf15aff64d982215e1/wxPython-4.0.7.post2.tar.gz",
+                    "sha256": "5a229e695b64f9864d30a5315e0c1e4ff5e02effede0a07f16e8d856737a0c4e"
                 },
                 {
                     "type": "script",
@@ -48,6 +49,7 @@
                 }
             ]
         },
+        "python3-wxPython.json",
         {
             "name": "OCE",
             "sources": [
@@ -117,6 +119,17 @@
             ]
         },
         {
+            "name": "swig",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://sourceforge.net/projects/swig/files/swig/swig-4.0.1/swig-4.0.1.tar.gz",
+                    "sha256": "7a00b4d0d53ad97a14316135e2d702091cd5f193bb58bcfcd8bc59d41e7887a9"
+                }
+            ],
+            "buildsystem": "autotools"
+        },
+        {
             "name": "kicad",
             "sources": [
                 {
@@ -131,16 +144,13 @@
                     ]
                 }
             ],
-            "buildsystem": "cmake-ninja",
+            "buildsystem": "cmake",
             "config-opts": [
                 "-DBOOST_ROOT=/app",
                 "-DGLEW_INCLUDE_DIR=/app/include/GL",
                 "-DOPENGL_glu_LIBRARY=/app/lib/libGLU.so",
-                "-DKICAD_SCRIPTING=OFF",
-                "-DKICAD_SCRIPTING_MODULES=OFF",
-                "-DKICAD_SCRIPTING_WXPYTHON=OFF",
-                "-DKICAD_SPICE=ON",
-                "-DKICAD_SCRIPTING_ACTION_MENU=OFF"
+                "-DKICAD_SCRIPTING_PYTHON3=ON",
+                "-DKICAD_SCRIPTING_WXPYTHON_PHOENIX=ON"
             ]
         },
         {

--- a/org.kicad_pcb.KiCad.json
+++ b/org.kicad_pcb.KiCad.json
@@ -138,13 +138,17 @@
                     "sha256": "ac1a15e25a7ff0aca4b6224bdb2d3298081b43bedfad79470339d53d5e72beb0"
                 },
                 {
+                    "type": "patch",
+                    "path": "fix-cmake-ninja-build.patch"
+                },
+                {
                     "type": "shell",
                     "commands": [
                         "sed -i '5s/org\.kicad_pcb\.kicad/org.kicad_pcb.KiCad/' resources/linux/appdata/kicad.appdata.xml.in"
                     ]
                 }
             ],
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DBOOST_ROOT=/app",
                 "-DGLEW_INCLUDE_DIR=/app/include/GL",

--- a/python3-wxPython.json
+++ b/python3-wxPython.json
@@ -1,0 +1,69 @@
+{
+    "name": "python3-wxPython",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-Cython",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} Cython"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/9c/9b/706dac7338c2860cd063a28cdbf5e9670995eaea408abbf2e88ba070d90d/Cython-0.29.14.tar.gz",
+                    "sha256": "e4d6bb8703d0319eb04b7319b12ea41580df44fd84d83ccda13ea463c6801414"
+                }
+            ]
+        },
+        {
+            "name": "python3-wheel",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} wheel"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/8c/23/848298cccf8e40f5bbb59009b32848a4c38f4e7f3364297ab3c3e2e2cd14/wheel-0.34.2-py2.py3-none-any.whl",
+                    "sha256": "df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e"
+                }
+            ]
+        },
+        {
+            "name": "python3-wxPython",
+            "buildsystem": "simple",
+            "build-options": {
+                "env": {
+                    "WXPYTHON_BUILD_ARGS": "--use_syswx"
+                }
+            },
+            "build-commands": [
+                "pip3 install -v --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} wxPython"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/40/de/0ea5092b8bfd2e3aa6fdbb2e499a9f9adf810992884d414defc1573dca3f/numpy-1.18.1.zip",
+                    "sha256": "b6ff59cee96b454516e47e7721098e6ceebef435e3e21ac2d6c3b8b02628eb77"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/65/eb/1f97cb97bfc2390a276969c6fae16075da282f5058082d4cb10c6c5c1dba/six-1.14.0-py2.py3-none-any.whl",
+                    "sha256": "8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/39/47/f28067b187dd664d205f75b07dcc6e0e95703e134008a14814827eebcaab/Pillow-7.0.0.tar.gz",
+                    "sha256": "4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b9/8b/31267dd6d026a082faed35ec8d97522c0236f2e083bf15aff64d982215e1/wxPython-4.0.7.post2.tar.gz",
+                    "sha256": "5a229e695b64f9864d30a5315e0c1e4ff5e02effede0a07f16e8d856737a0c4e"
+                }
+            ]
+        }
+    ]
+}

--- a/python3-wxPython.json
+++ b/python3-wxPython.json
@@ -7,13 +7,13 @@
             "name": "python3-Cython",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} Cython"
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} Cython"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/9c/9b/706dac7338c2860cd063a28cdbf5e9670995eaea408abbf2e88ba070d90d/Cython-0.29.14.tar.gz",
-                    "sha256": "e4d6bb8703d0319eb04b7319b12ea41580df44fd84d83ccda13ea463c6801414"
+                    "url": "https://files.pythonhosted.org/packages/99/36/a3dc962cc6d08749aa4b9d85af08b6e354d09c5468a3e0edc610f44c856b/Cython-0.29.17.tar.gz",
+                    "sha256": "6361588cb1d82875bcfbad83d7dd66c442099759f895cf547995f00601f9caf2"
                 }
             ]
         },
@@ -21,7 +21,7 @@
             "name": "python3-wheel",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} wheel"
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} wheel"
             ],
             "sources": [
                 {
@@ -40,13 +40,13 @@
                 }
             },
             "build-commands": [
-                "pip3 install -v --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} wxPython"
+                "pip3 install --exists-action=i --no-index --no-build-isolation --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} wxPython"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/40/de/0ea5092b8bfd2e3aa6fdbb2e499a9f9adf810992884d414defc1573dca3f/numpy-1.18.1.zip",
-                    "sha256": "b6ff59cee96b454516e47e7721098e6ceebef435e3e21ac2d6c3b8b02628eb77"
+                    "url": "https://files.pythonhosted.org/packages/2d/f3/795e50e3ea2dc7bc9d1a2eeea9997d5dce63b801e08dfc37c2efce341977/numpy-1.18.4.zip",
+                    "sha256": "bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509"
                 },
                 {
                     "type": "file",
@@ -55,8 +55,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/39/47/f28067b187dd664d205f75b07dcc6e0e95703e134008a14814827eebcaab/Pillow-7.0.0.tar.gz",
-                    "sha256": "4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946"
+                    "url": "https://files.pythonhosted.org/packages/ce/ef/e793f6ffe245c960c42492d0bb50f8d14e2ba223f1922a5c3c81569cec44/Pillow-7.1.2.tar.gz",
+                    "sha256": "a0b49960110bc6ff5fead46013bcb8825d101026d466f3a4de3476defe0fb0dd"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
This PR activates Python 3 scripting, using wxPython Phoenix.

Note that this effectively also switches from wxWidgets 3.1.2 to the wxWidgets bundled with wxPython Phoenix 4.0.7.post2 as recommended by the wxPython docs. The bundled wxWidgets calls itself version 3.0.5.