### PR TITLE
Add KiCad's user documentation

### DIFF
--- a/org.kicad_pcb.KiCad.json
+++ b/org.kicad_pcb.KiCad.json
@@ -23,7 +23,6 @@
         "/lib64",
         "/share/aclocal",
         "/share/bakefile",
-        "/share/doc",
         "*.la",
         "*.a"
     ],
@@ -214,6 +213,20 @@
             "builddir": true,
             "config-opts": [
                 "-DKICAD_I18N_UNIX_STRICT_PATH=ON"
+            ]
+        },
+        {
+            "name": "kicad-doc",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://kicad-downloads.s3.cern.ch/docs/kicad-doc-5.1.6.tar.gz",
+                    "sha256": "3abb7f96269d146023463edb0a5eaaeb73ff4f7b1b6948a5d97deeaf625aecd0"
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "find . -type f -exec install -Dm644 \"{}\" \"${FLATPAK_DEST}/{}\" \\;"
             ]
         }
     ]

--- a/org.kicad_pcb.KiCad.json
+++ b/org.kicad_pcb.KiCad.json
@@ -143,7 +143,7 @@
                 {
                     "type": "shell",
                     "commands": [
-                        "sed -i '5s/org\.kicad_pcb\.kicad/org.kicad_pcb.KiCad/' resources/linux/appdata/kicad.appdata.xml.in"
+                        "sed -i '5s/org\.kicad_pcb\.kicad/org.kicad_pcb.KiCad/;96i<kudos><kudo>UserDocs</kudo></kudos>' resources/linux/appdata/kicad.appdata.xml.in"
                     ]
                 }
             ],


### PR DESCRIPTION
While it's fixing a user reported issue, this will increase the install size significantly. So, we might be considering to move this out to an extension, like it is proposed to be done for the 3D packages (see #32).

Closes #21