### PR TITLE
Update KiCad sources + libraries to v5.1.8

### DIFF
--- a/org.kicad_pcb.KiCad.json
+++ b/org.kicad_pcb.KiCad.json
@@ -170,8 +170,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.com/kicad/code/kicad/-/archive/5.1.7/kicad-5.1.7.tar.gz",
-                    "sha256": "96ad30aa289ed6f77ffcd8283d0877b700139187e5f1957acad8ad4dbad472bc"
+                    "url": "https://gitlab.com/kicad/code/kicad/-/archive/5.1.8/kicad-5.1.8.tar.gz",
+                    "sha256": "bf24f8ef427b4a989479b8e4af0b8ae5c54766755f12748e2e88a922c5344ca4"
                 },
                 {
                     "type": "patch",
@@ -208,8 +208,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.com/kicad/code/kicad-i18n/-/archive/5.1.7/kicad-i18n-5.1.7.tar.gz",
-                    "sha256": "be72fc4488d8b614b2b7997669641d0adeabe689083253b5c6bfb99853171542"
+                    "url": "https://gitlab.com/kicad/code/kicad-i18n/-/archive/5.1.8/kicad-i18n-5.1.8.tar.gz",
+                    "sha256": "1c4138f4663e072ac6c742d73ccc0984b2de7be202b37155aacbd4f17e645317"
                 }
             ],
             "buildsystem": "cmake-ninja",
@@ -223,8 +223,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://kicad-downloads.s3.cern.ch/docs/kicad-doc-5.1.7.tar.gz",
-                    "sha256": "552156c0dbf05ac3767b49d294f2f99c4963621e06577042d311ac470490eb21"
+                    "url": "https://kicad-downloads.s3.cern.ch/docs/kicad-doc-5.1.8.tar.gz",
+                    "sha256": "f2d96bae9bb44c089b155ee61bb589d51373647cdfdf28b5f931756e369bdf14"
                 }
             ],
             "buildsystem": "simple",
@@ -237,8 +237,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/KiCad/kicad-templates/archive/5.1.7.tar.gz",
-                    "sha256": "0454a08872e39c7f5f038f4447606ec05d7e327684a8361ccb71e7e3d497bbb2"
+                    "url": "https://gitlab.com/kicad/libraries/kicad-templates/-/archive/5.1.8/kicad-templates-5.1.8.tar.gz",
+                    "sha256": "1afc8196f47d053937c2db9ee7f09b0d812e1ba93e57a0610ab1ced21c9134ca"
                 }
             ],
             "buildsystem": "cmake-ninja"
@@ -248,8 +248,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/KiCad/kicad-symbols/archive/5.1.7.tar.gz",
-                    "sha256": "ab8fe5a65a7c1a99d9b85f82c56cc7b2dbe77eb37e28945481dcddad7378b425"
+                    "url": "https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/5.1.8/kicad-symbols-5.1.8.tar.gz",
+                    "sha256": "a5ca226afbabdd1822c4a18e63a2943cd2913df11e8e50530768fbdd7997ba54"
                 }
             ],
             "buildsystem": "cmake-ninja"
@@ -259,8 +259,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/KiCad/kicad-footprints/archive/5.1.7.tar.gz",
-                    "sha256": "2720e009285fbafa44216417c71d438833398ccb4a23d9c6cce86170983817fa"
+                    "url": "https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/5.1.8/kicad-footprints-5.1.8.tar.gz",
+                    "sha256": "31c3676d71139259f1cc67b3a0254ec8a8659d35f2c51a273f5de542c651a819"
                 }
             ],
             "buildsystem": "cmake-ninja"


### PR DESCRIPTION
- Switch libraries to download from Gitlab

Missing (no 5.1.8 tag yet):
- Use tip of 5.1 branch instead
- Documentation