### PR TITLE
Alter KISYS3DMOD env var to point to extra-data

### DIFF
--- a/org.kicad_pcb.KiCad.json
+++ b/org.kicad_pcb.KiCad.json
@@ -10,7 +10,7 @@
     "finish-args": [
         "--device=dri",
         "--env=LD_LIBRARY_PATH=/app/lib",
-        "--env=KISYS3DMOD=/app/library-extensions/Packages3D/share/kicad/modules/packages3d",
+        "--env=KISYS3DMOD=/app/library-extensions/Packages3D/extra",
         "--filesystem=home",
         "--share=ipc",
         "--share=network",


### PR DESCRIPTION
https://github.com/flathub/org.kicad_pcb.KiCad.Library.Packages3D/pull/3 downloads the 3D packages as `extra-data` at installation time. This changes the directory structure of the extension, and thus the `KISYS3DMOD` environment variable needs an adjustment.