### PR TITLE
Mark repo as end-of-life due to rename

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "The application has been renamed to org.kicad.KiCad.",
+  "end-of-life-rebase": "org.kicad.KiCad"
+}


### PR DESCRIPTION
New app-id: org.kicad.KiCad.

To be merged after:
- https://github.com/flathub/flathub/pull/2041
- https://github.com/flathub/flathub/pull/2042
have landed.

@bilelmoussaoui As per https://github.com/flathub/flathub/wiki/App-Maintenance#end-of-life , it would be great if you could archive the repo after this has been merged.

Also, do I need to mark the extension https://github.com/flathub/org.kicad_pcb.KiCad.Library.Packages3D as end-of-life as well?